### PR TITLE
update-conda to false

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup conda
         uses: s-weigand/setup-conda@v1
         with:
-         update-conda: true
+         update-conda: false
          python-version: ${{ matrix.python-version }}
          conda-channels: anaconda, conda-forge
       - run: conda --version


### PR DESCRIPTION
New conda version (4.11.0) breaks builds for python 3.6. Setting update-conda to false seems to resolve that issue for now.