### PR TITLE
unpin package dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     install_requires=[
-        'pyaml', 'chemparse', 'scipy<=1.5.4', 'numpy<=1.19.5', 'networkx<=2.5.1',
+        'pyaml', 'chemparse', 'scipy', 'numpy', 'networkx',
         'plams@git+https://github.com/SCM-NV/PLAMS@master'],
     extras_require={
         'test': ['coverage', 'pytest>=3.9', 'pytest-cov'],


### PR DESCRIPTION
We should unpin these again to make it easier to support several python versions.