### PR TITLE
Convert to using pyproject.toml

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -24,9 +24,7 @@ project, htmlhelp_basename, latex_documents = set_project_specific_var("pyZacros
 
 # html_logo = '_static/pyZacros_logo_compact.svg'
 
-extensions += [
-    "sphinx.ext.autodoc",
-]
+extensions += ["sphinx.ext.autodoc", "sphinx_copybutton"]
 
 # Avoid duplicate names by prefixing the document's name.
 # autosectionlabel_prefix_document = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,64 @@
+[project]
+name = "pyzacros"
+dynamic = ["version"]
+description = "Python Library for Automating Zacros Simulations"
+readme = "README.md"
+requires-python = ">=3.8"
+license = { text = "LGPLv3" }
+authors = [
+    { name = "Nestor F. Aguirre", email = "aguirre@scm.com" },
+    { name = "Pablo Lopez-Tarifa" },
+    { name = "Software for Chemistry & Materials", email = "info@scm.com" }
+]
+maintainers = [
+    { name = "Software for Chemistry & Materials", email = "info@scm.com" }
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Topic :: Scientific/Engineering :: Chemistry",
+    "Topic :: Scientific/Engineering :: Physics",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+keywords=["molecular modeling", "computational chemistry", "workflow", "python interface"]
+dependencies = [
+    "chemparse>=0.1.1",
+    "matplotlib>=3.5.1",
+    "networkx>=2.7.1",
+    "numpy>=1.21.2",
+    "scipy>=1.8.0",
+    "plams>=2025",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=7.4.0",
+    "coverage>=7.5.3",
+    "pytest-cov>=3"
+]
+
+doc = [
+    "sphinx>=6.2.1,<8.2",
+    "sphinx-rtd-theme>=3.0.1",
+    "sphinx_copybutton>=0.5.2",
+    "nbconvert>=6.4.5"
+]
+
+[project.urls]
+Homepage = "https://www.scm.com/doc/pyzacros/index.html"
+Documentation = "https://www.scm.com/doc/pyzacros/index.html"
+GitHub = "https://github.com/SCM-NV/pyZacros"
+
+[build-system]
+requires = ["setuptools >= 61.0"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+package-dir = { "scm.pyzacros" = "." }
+
+[tool.setuptools.dynamic]
+version = {attr = "__version__.__version__"}

--- a/setup.py
+++ b/setup.py
@@ -1,64 +1,31 @@
-#!/usr/bin/env python
+from setuptools import find_packages, setup
+from glob import glob
 import os
 
-from setuptools import setup, find_packages
+# This minimal setup.py exists alongside the pyproject.toml for legacy reasons.
+# Currently, the "artificial" prefix "scm." is added to the (sub)package names, which is not supported via the pyproject.toml.
+# ToDo: the package should be restructured with a directory structure that reflects this, then the setuptools package finding used.
+# See: https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html
+doc_files = [
+    os.path.relpath(path)  # relative to package_dir
+    for path in glob("doc/*")
+    if os.path.isfile(path)
+]
 
-description = "pyZacros (Python Library for Automating Zacros Simulation) is a collection of tools that aims to provide a powerful, flexible, and easily extendable Python interface to Zacros, a Kinetic Monte Carlo software package for simulating molecular phenomena on catalytic surfaces. pyZacros is designed as an extension of the python library [PLAMS](https://github.com/SCM-NV/PLAMS). Thereby inherits from PLAMS the robust way of managing the inputs file preparation, job execution, file management, and output file processing. Above that, it also offers the possibility of postprocessing the results and building very advanced data workflows."
+test_files = [
+    os.path.relpath(path)  # relative to package_dir
+    for path in glob("tests/**", recursive=True)
+    if os.path.isfile(path)
+]
 
-here = os.path.abspath(os.path.dirname(__file__))
-
-packages = ["scm.pyzacros"] + ["scm.pyzacros." + i for i in find_packages(".")]
-
-# To update the package version number, edit pyZacros/__version__.py
-version = {}
-with open(os.path.join(here, "__version__.py")) as f:
-    exec(f.read(), version)
-
-with open("README.md") as readme_file:
-    readme = readme_file.read()
-
-
-def package_files(directory):
-    paths = []
-    for path, directories, filenames in os.walk(directory):
-        for filename in filenames:
-            paths.append(os.path.join("..", path, filename))
-    return paths
-
-
-extra_data_files = []
-extra_data_files.extend(package_files("examples"))
-extra_data_files.extend(package_files("tests"))
+examples_files = [
+    os.path.relpath(path)  # relative to package_dir
+    for path in glob("examples/**", recursive=True)
+    if os.path.isfile(path)
+]
 
 setup(
-    name="pyzacros",
-    version=version["__version__"],
-    description="Python Library for Automating Zacros Simulations",
-    long_description=description,
-    author="Nestor F. Aguirre & Pablo Lopez-Tarifa",
-    author_email="aguirre@scm.com",
-    url="https://github.com/SCM-NV/pyZacros",
-    packages=packages,
+    packages=["scm.pyzacros"] + ["scm.pyzacros." + i for i in find_packages(".")],
     package_dir={"scm.pyzacros": "."},
-    package_data={"": extra_data_files},
-    include_package_data=True,
-    license="LGPLv3",
-    zip_safe=False,
-    keywords=["molecular modeling", "computational chemistry", "workflow", "python interface"],
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
-        "Natural Language :: English",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Topic :: Scientific/Engineering :: Chemistry",
-        "Topic :: Scientific/Engineering :: Physics",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-    ],
-    install_requires=["chemparse", "scipy", "numpy", "networkx", "plams@git+https://github.com/SCM-NV/PLAMS@master"],
-    extras_require={
-        "test": ["coverage", "pytest>=3.9", "pytest-cov"],
-        "doc": ["sphinx", "sphinx_rtd_theme", "nbsphinx"],
-    },
+    package_data={"scm.pyzacros": doc_files + test_files + examples_files},
 )


### PR DESCRIPTION
# Description

Swap to using a more modern `pyproject.toml` file in place of the `setup.py`. 

The information from the `setup.py` has been copied across. In addition, minimum requirements have been added for dependencies, which correspond to those from the `amspython` stack.

Note that a minimal `setup.py` is still retained for now to handle the `scm.` prefix on the packaging imports.