### PR TITLE
Update build.yml to remove plams pinned version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,7 @@ jobs:
           pip3 install .[test,doc]
           pip3 install build
           python -m build
-          # use plams<2025 until bug fixed in 2025 for loading legacy dill files
-          pip3 install dist/pyzacros-*.whl plams==2024.106
+          pip3 install dist/pyzacros-*.whl
       - name: Test
         run: |
           pytest tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "networkx>=2.7.1",
     "numpy>=1.21.2",
     "scipy>=1.8.0",
-    "plams>=2024",
+    "plams>2025,<=2025.299",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "chemparse>=0.1.1",
     "matplotlib>=3.5.1",
     "networkx>=2.7.1",
-    "numpy>=1.21.2",
+    "numpy>=1.21.2,<2",
     "scipy>=1.8.0",
     "plams>2025,<=2025.299",
 ]


### PR DESCRIPTION
Remove the constraint on PLAMS version in testing, now a bug for reading old rkfs was fixed in 2025.104.

Add constraint on numpy version <2, as the unit tests were failing on python3.9.