### PR TITLE
Update build.yml to test python 3.8-3.13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest']
-        python-version: ['3.8', '3.9']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
       - uses: actions/checkout@v2
       - name: Setup conda

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: Build
 
 on:
+  push:
+    branches:
+      - trunk   
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
 name: Build
 
-on: [push, pull_request]
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
          conda-channels: anaconda, conda-forge
       - run: conda --version
       - run: python --version
-      - run: conda install python=${{ matrix.python-version }} "certifi=2021.5.30"
+      - run: conda install python=${{ matrix.python-version }}
       - name: Build
         run: |
           pip3 install .[test,doc]


### PR DESCRIPTION
# Description

Expand the testing matrix to include python versions from 3.8-3.13, instead of just 3.8 and 3.9

In addition I changed the testing just to run on PR creation and updates (i.e. new commits), and direct pushes to trunk, to stop the duplication of jobs on push. 

Also removed the `certifi` dependency - I don't see why it is needed and it was pinned to a very old version